### PR TITLE
Update matrix.c to work with QMK Firmware 0.28.0

### DIFF
--- a/keyboards/keebart/3w6_rgb/matrix.c
+++ b/keyboards/keebart/3w6_rgb/matrix.c
@@ -60,7 +60,7 @@ uint8_t init_tca9555(void) {
         // This means: we will write on pins 0 to 3 on port 1. read rest
         0b11110000,
     };
-    tca9555_status = i2c_writeReg(I2C_ADDR, IODIRA, conf, 2, I2C_TIMEOUT);
+    tca9555_status = i2c_write_register(I2C_ADDR, IODIRA, conf, 2, I2C_TIMEOUT);
 
     return tca9555_status;
 }
@@ -179,7 +179,7 @@ static matrix_row_t read_cols(uint8_t row) {
         } else {
             uint8_t data   = 0;
             uint8_t port0  = 0;
-            tca9555_status = i2c_readReg(I2C_ADDR, IREGP0, &port0, 1, I2C_TIMEOUT);
+            tca9555_status = i2c_read_register(I2C_ADDR, IREGP0, &port0, 1, I2C_TIMEOUT);
             if (tca9555_status) { // if there was an error
                 // do nothing
                 return 0;
@@ -241,7 +241,7 @@ static void select_row(uint8_t row) {
                     break;
             }
 
-            tca9555_status = i2c_writeReg(I2C_ADDR, OREGP1, &port1, 1, I2C_TIMEOUT);
+            tca9555_status = i2c_write_register(I2C_ADDR, OREGP1, &port1, 1, I2C_TIMEOUT);
         }
     }
 }


### PR DESCRIPTION
<!---

    If you are submitting a Vial-enabled keymap for a keyboard in QMK:

    - Keymaps will not be accepted with VIAL_INSECURE=yes.
    - Avoid changing keyboard-level code if possible. (ex: switching the encoder pins in info.json)
    - Please name your keymap "vial". Personal keymaps are not accepted at this time.
      - If your Vial keymap only works for a specific keyboard revision, place it under that revision's folder. (ex: keyboards/planck/rev6_drop/keymaps/vial and keyboards/planck/ez/glow/keymaps/vial)

    If you are submitting a new keyboard with keymaps:

    - If you are also submitting this keyboard to QMK, please try to submit mostly the same code to both repos if possible.
    - If you are not submitting this keyboard to QMK, only include "default" and "vial" keymaps. VIA firmware can no longer be built by this repository.

    ------

    For all keyboard and keymap submissions:

    As the submitter, you are ultimately responsible for maintaining the keyboards/keymaps you submit.
    Vial contributors will try to fix compilation issues as updates are made, but are not always familiar with and often can't test specific keymaps/keyboards.

    Vial is decentralized, so inclusion in the vial-qmk repository is optional. Unmaintained keymaps/keyboards which are broken and cannot be fixed without extensive rework or strong familiarity with the hardware may be removed from this repository, with or without warning.

    ------

    For core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->

The current code isn't compiling with the latest QMK firmware.

Functions "i2c_writeReg" and "i2c_readReg" seem to be deprecated names. Replacing them with "i2c_write_register" and "i2c_read_register" fixes the issue.