### PR TITLE
fix: replace deprecated ast.Num with ast.Constant 

### DIFF
--- a/lib/python/qmk/math.py
+++ b/lib/python/qmk/math.py
@@ -23,8 +23,8 @@ def compute(expr):
 
 
 def _eval(node):
-    if isinstance(node, ast.Num):  # <number>
-        return node.n
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):  # <number>
+        return node.value
     elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
         return operators[type(node.op)](_eval(node.left), _eval(node.right))
     elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1


### PR DESCRIPTION
ast.Num was removed in Python 3.12. Replace it with ast.Constant and check that the value is int or float to preserve the same behavior.